### PR TITLE
Move computation off client thread

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
-    implementation "org.java-websocket:Java-WebSocket:1.4.0"
+    implementation "org.java-websocket:Java-WebSocket:1.5.6"
 
     testImplementation 'junit:junit:4.12'
     testImplementation group: 'net.runelite', name: 'client', version: runeLiteVersion

--- a/src/main/java/com/andmcadams/wikisync/dps/DpsDataFetcher.java
+++ b/src/main/java/com/andmcadams/wikisync/dps/DpsDataFetcher.java
@@ -38,15 +38,10 @@ public class DpsDataFetcher
 	@Getter
 	private String username;
 
-	// TODO: Delete this once the Wiki plugin service exists. See https://github.com/runelite/runelite/pull/17524
-	@Getter
-	private JsonObject loadout;
-
 	@Subscribe
 	public void onGameTick(GameTick e)
 	{
 		checkUsername();
-		checkLoadout();
 	}
 
 	@Subscribe
@@ -104,7 +99,7 @@ public class DpsDataFetcher
 
 	// TODO: Delete this once the Wiki plugin service exists. See https://github.com/runelite/runelite/pull/17524
 	// This is directly copied from https://github.com/runelite/runelite/pull/17524/files#diff-141a15aba5d017de9818b5d39722f85f95b330ef96f8eb06103a947c1094b905
-	private JsonObject buildShortlinkData()
+	public JsonObject buildShortlinkData()
 	{
 		JsonObject j = new JsonObject();
 
@@ -152,17 +147,6 @@ public class DpsDataFetcher
 		j.add("loadouts", loadouts);
 
 		return j;
-	}
-
-	private void checkLoadout()
-	{
-		JsonObject currentLoadout = buildShortlinkData();
-
-		if (!Objects.equals(this.loadout, currentLoadout))
-		{
-			log.debug("WS loadout changed prev=[{}] next=[{}]", this.loadout, currentLoadout);
-			this.loadout = currentLoadout;
-		}
 	}
 
 }

--- a/src/main/java/com/andmcadams/wikisync/dps/WebSocketManager.java
+++ b/src/main/java/com/andmcadams/wikisync/dps/WebSocketManager.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -47,7 +48,11 @@ public class WebSocketManager implements WSHandler
 	@Inject
 	private ClientThread clientThread;
 
-	private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
+	private static final ExecutorService executorService = Executors.newSingleThreadExecutor(r -> {
+		Thread t = new Thread(r);
+		t.setDaemon(true);
+		return t;
+	});
 
 	public void startUp()
 	{

--- a/src/main/java/com/andmcadams/wikisync/dps/WebSocketManager.java
+++ b/src/main/java/com/andmcadams/wikisync/dps/WebSocketManager.java
@@ -8,7 +8,6 @@ import com.andmcadams.wikisync.dps.ws.WSWebsocketServer;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
@@ -169,7 +168,7 @@ public class WebSocketManager implements WSHandler
 				{
 					this.server.stop();
 				}
-				catch (InterruptedException | IOException e)
+				catch (InterruptedException e)
 				{
 					// ignored
 				}

--- a/src/main/java/com/andmcadams/wikisync/dps/ws/WSWebsocketServer.java
+++ b/src/main/java/com/andmcadams/wikisync/dps/ws/WSWebsocketServer.java
@@ -13,6 +13,7 @@ public class WSWebsocketServer extends WebSocketServer
 	public WSWebsocketServer(int port, WSHandler handler)
 	{
 		super(new InetSocketAddress("127.0.0.1", port));
+		this.setDaemon(true);
 		this.handler = handler;
 	}
 


### PR DESCRIPTION
Currently we check for any changes to the player's loadout every tick. Let's stop doing that and only lookup the player's loadout if requested.

Also, as soon as we are done looking up player data on the client thread, we now use a separate thread to schedule WebSocket messages to clients.

Lastly, I upgraded the Java-WebSockets library to the latest version. An important change is using separate threads for sending/receiving messages!