### PR TITLE
Fix bug that causes us to continuously fire if we remove a val from the manifest

### DIFF
--- a/src/main/java/com/andmcadams/wikisync/PlayerData.java
+++ b/src/main/java/com/andmcadams/wikisync/PlayerData.java
@@ -17,8 +17,8 @@ public class PlayerData
     Map<Integer, Integer> varp = new HashMap<>();
     Map<String, Integer> level = new HashMap<>();
 
-	public boolean isEmpty()
-	{
-		return varb.isEmpty() && varp.isEmpty() && level.isEmpty();
-	}
+    public boolean isEmpty()
+    {
+        return varb.isEmpty() && varp.isEmpty() && level.isEmpty();
+    }
 }

--- a/src/main/java/com/andmcadams/wikisync/PlayerData.java
+++ b/src/main/java/com/andmcadams/wikisync/PlayerData.java
@@ -16,4 +16,8 @@ public class PlayerData
     Map<Integer, Integer> varb = new HashMap<>();
     Map<Integer, Integer> varp = new HashMap<>();
     Map<String, Integer> level = new HashMap<>();
+
+	public boolean isEmpty() {
+		return varb.isEmpty() && varp.isEmpty() && level.isEmpty();
+	}
 }

--- a/src/main/java/com/andmcadams/wikisync/PlayerData.java
+++ b/src/main/java/com/andmcadams/wikisync/PlayerData.java
@@ -17,7 +17,8 @@ public class PlayerData
     Map<Integer, Integer> varp = new HashMap<>();
     Map<String, Integer> level = new HashMap<>();
 
-	public boolean isEmpty() {
+	public boolean isEmpty()
+	{
 		return varb.isEmpty() && varp.isEmpty() && level.isEmpty();
 	}
 }

--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -196,12 +196,11 @@ public class WikiSyncPlugin extends Plugin
 
 		PlayerData newPlayerData = getPlayerData();
 		PlayerData oldPlayerData = playerDataMap.computeIfAbsent(profileKey, k -> new PlayerData());
-		if (newPlayerData.equals(oldPlayerData))
-		{
-			return;
-		}
 
+		// Subtraction is done in place so newPlayerData becomes a map of only changed fields
 		subtract(newPlayerData, oldPlayerData);
+		if (newPlayerData.isEmpty())
+			return;
 		submitPlayerData(profileKey, newPlayerData, oldPlayerData);
 	}
 

--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -200,7 +200,9 @@ public class WikiSyncPlugin extends Plugin
 		// Subtraction is done in place so newPlayerData becomes a map of only changed fields
 		subtract(newPlayerData, oldPlayerData);
 		if (newPlayerData.isEmpty())
+		{
 			return;
+		}
 		submitPlayerData(profileKey, newPlayerData, oldPlayerData);
 	}
 


### PR DESCRIPTION
The existing code has a bug where removing a value from the manifest will cause all future submission attempts to go through.

The early return only fires if the new and old changes are equivalent. If you remove something from the manifest, that kv pair wont exist in the newPlayerData. That means the new and oldPlayerData cannot be equal and the early return will not happen. Because we just fire off the set difference of new - old, that leads to us getting a shitton of blank submissions.

This change removes that check in favor of checking if the delta itself is empty. This is what we actually want to do, since it's checking that the new - old set difference is empty. I added an isEmpty method on the PlayerData itself so when someone goes to add something new to PlayerData they hopefully notice the function below and update it.

In case they don't notice, it will skew in the direction of fewer submissions than expected, and should only break for newly added fields. If only the new field type has changes, we won't push anything, otherwise we operate normally. That feels relatively safe, but I don't see us adding a new type in the near future anyway.