### PR TITLE
Add collection log support

### DIFF
--- a/src/main/java/com/andmcadams/wikisync/Manifest.java
+++ b/src/main/java/com/andmcadams/wikisync/Manifest.java
@@ -2,10 +2,13 @@ package com.andmcadams.wikisync;
 
 import lombok.Data;
 
+import java.util.ArrayList;
+
 @Data
 public class Manifest
 {
     final int version = -1;
     final int[] varbits = new int[0];
     final int[] varps = new int[0];
+    final ArrayList<Integer> collections = new ArrayList<>();
 }

--- a/src/main/java/com/andmcadams/wikisync/PlayerData.java
+++ b/src/main/java/com/andmcadams/wikisync/PlayerData.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,9 +17,15 @@ public class PlayerData
     Map<Integer, Integer> varb = new HashMap<>();
     Map<Integer, Integer> varp = new HashMap<>();
     Map<String, Integer> level = new HashMap<>();
+    String collectionLog = "";
 
     public boolean isEmpty()
     {
-        return varb.isEmpty() && varp.isEmpty() && level.isEmpty();
+        return varb.isEmpty() && varp.isEmpty() && level.isEmpty() && collectionLog.isEmpty();
+    }
+
+    public void clearCollectionLog()
+    {
+        collectionLog = "";
     }
 }

--- a/src/main/java/com/andmcadams/wikisync/PlayerData.java
+++ b/src/main/java/com/andmcadams/wikisync/PlayerData.java
@@ -1,11 +1,9 @@
 package com.andmcadams.wikisync;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
+++ b/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
@@ -112,7 +112,7 @@ public class SyncButtonManager {
 
     void onButtonClick() {
         client.menuAction(-1, 40697932, MenuAction.CC_OP, 1, -1, "Search", null);
-        client.menuAction(-1, 40697932, MenuAction.CC_OP, 1, -1, "Back", null);
+        client.runScript(2240);
         client.addChatMessage(ChatMessageType.CONSOLE, "WikiSync", "Your collection log data is being sent to WikiSync...", "WikiSync");
     }
 

--- a/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
+++ b/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
@@ -6,12 +6,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.annotations.Component;
-import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.widgets.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.EventBus;
-import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.eventbus.Subscribe;
 
@@ -45,6 +43,9 @@ public class SyncButtonManager {
 
     private static final int FONT_COLOUR_INACTIVE = 0xd6d6d6;
     private static final int FONT_COLOUR_ACTIVE = 0xffffff;
+    private static final int CLOSE_BUTTON_OFFSET = 28;
+    private static final int BUTTON_WIDTH = 71;
+    private static final int BUTTON_OFFSET = CLOSE_BUTTON_OFFSET + 5;
 
     private final Client client;
     private final ClientThread clientThread;
@@ -79,7 +80,7 @@ public class SyncButtonManager {
     enum Screen
     {
         // First number is col log container (inner) and second is search button id
-        COLLECTION_LOG(40697944, 40697932, ComponentID.COLLECTION_LOG_CONTAINER, 55),
+        COLLECTION_LOG(40697944, 40697932, ComponentID.COLLECTION_LOG_CONTAINER),
         ;
 
         @Getter(onMethod_ = @Component)
@@ -90,8 +91,6 @@ public class SyncButtonManager {
 
         @Getter(onMethod_ = @Component)
         private final int collectionLogContainer;
-
-        private final int originalX;
     }
 
     void tryAddButton(Runnable onClick)
@@ -120,56 +119,95 @@ public class SyncButtonManager {
     void addButton(Screen screen, Runnable onClick)
     {
         Widget parent = client.getWidget(screen.getParentId());
-        Widget setBonus = client.getWidget(screen.getSearchButtonId());
+        Widget searchButton = client.getWidget(screen.getSearchButtonId());
         Widget collectionLogContainer = client.getWidget(screen.getCollectionLogContainer());
         Widget[] containerChildren;
         Widget draggableTopbar;
-        Widget[] refComponents;
-        if (parent == null || setBonus == null || collectionLogContainer == null ||
+        if (parent == null || searchButton == null || collectionLogContainer == null ||
             (containerChildren = collectionLogContainer.getChildren()) == null ||
-                (draggableTopbar = containerChildren[0]) == null  ||
-                (refComponents = setBonus.getChildren()) == null)
+                (draggableTopbar = containerChildren[0]) == null)
         {
             return;
         }
 
-        final int w = setBonus.getOriginalWidth();
-        final int h = setBonus.getOriginalHeight();
-        final int x = parent.getOriginalWidth() - 103;
-        final int y = setBonus.getOriginalY();
+        final int w = BUTTON_WIDTH;
+        final int h = searchButton.getOriginalHeight();
+        final int x = BUTTON_OFFSET;
+        final int y = searchButton.getOriginalY();
+        final int cornerDim = 9;
 
         final Widget[] spriteWidgets = new Widget[9];
 
-        int bgWidth = w - refComponents[0].getOriginalWidth();
-        int bgHeight = h - refComponents[0].getOriginalHeight();
-        int bgX = (x) + (w - bgWidth) / 2;
-        int bgY = (y) + (h - bgHeight) / 2;
         spriteWidgets[0] = parent.createChild(-1, WidgetType.GRAPHIC)
-                .setSpriteId(refComponents[0].getSpriteId())
-                .setPos(bgX, bgY)
-                .setSize(bgWidth, bgHeight)
-                .setYPositionMode(setBonus.getYPositionMode());
-        spriteWidgets[0].revalidate();
+                .setSpriteId(SPRITE_IDS_INACTIVE[0])
+                .setPos(x, y)
+                .setSize(w, h)
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setYPositionMode(searchButton.getYPositionMode());
 
-        for (int i = 1; i < 9; i++)
+        spriteWidgets[1] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[1])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(cornerDim, cornerDim)
+                .setPos(x + (w - cornerDim), y);
+        spriteWidgets[2] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[2])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(cornerDim, cornerDim)
+                .setPos(x, y);
+        spriteWidgets[3] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[3])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(cornerDim, cornerDim)
+                .setPos(x + (w - cornerDim), y + h - cornerDim);
+        spriteWidgets[4] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[4])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(cornerDim, cornerDim)
+                .setPos(x, y + h - cornerDim);
+        // Left and right edges
+        int sideWidth = 9;
+        int sideHeight = 4;
+        spriteWidgets[5] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[5])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(sideWidth, sideHeight)
+                .setPos(x + (w - sideWidth), y + cornerDim);
+        spriteWidgets[7] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[7])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(sideWidth, sideHeight)
+                .setPos(x, y + cornerDim);
+
+        // Top and bottom edges
+        int topWidth = 53;
+        int topHeight = 9;
+        spriteWidgets[6] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[6])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(topWidth, topHeight)
+                .setPos(x + cornerDim, y);
+        spriteWidgets[8] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(SPRITE_IDS_INACTIVE[8])
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
+                .setSize(topWidth, topHeight)
+                .setPos(x + cornerDim, y + h - topHeight);
+        for (int i = 0; i < 9; i++)
         {
-            Widget c = spriteWidgets[i] = parent.createChild(-1, WidgetType.GRAPHIC)
-                    .setSpriteId(refComponents[i].getSpriteId())
-                    .setSize(refComponents[i].getOriginalWidth(), refComponents[i].getOriginalHeight())
-                    .setPos(x + refComponents[i].getOriginalX(), y + refComponents[i].getOriginalY());
             spriteWidgets[i].revalidate();
         }
 
         final Widget text = parent.createChild(-1, WidgetType.TEXT)
                 .setText("WikiSync")
                 .setTextColor(FONT_COLOUR_INACTIVE)
-                .setFontId(refComponents[10].getFontId())
-                .setTextShadowed(refComponents[10].getTextShadowed())
+                .setFontId(FontID.PLAIN_11)
+                .setTextShadowed(true)
+                .setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT)
                 .setXTextAlignment(WidgetTextAlignment.CENTER)
                 .setYTextAlignment(WidgetTextAlignment.CENTER)
                 .setPos(x, y)
                 .setSize(w, h)
-                .setYPositionMode(setBonus.getYPositionMode());
+                .setYPositionMode(searchButton.getYPositionMode());
         text.revalidate();
 
         // We'll give the text layer the listeners since it covers the whole area
@@ -191,13 +229,13 @@ public class SyncButtonManager {
             text.setTextColor(FONT_COLOUR_INACTIVE);
         });
 
-        // register a click listener
+        // Register a click listener
         text.setAction(0, "Sync your collection log with WikiSync");
         text.setOnOpListener((JavaScriptCallback) ev -> onClick.run());
 
 
-        //Shrink the top bar to avoid overlapping the new button
-        draggableTopbar.setOriginalWidth(draggableTopbar.getWidth() - w);
+        // Shrink the top bar to avoid overlapping the new button
+        draggableTopbar.setOriginalWidth(draggableTopbar.getOriginalWidth() - (w + (x - CLOSE_BUTTON_OFFSET)));
         draggableTopbar.revalidate();
 
         // recompute locations / sizes on parent

--- a/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
+++ b/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
@@ -1,0 +1,248 @@
+package com.andmcadams.wikisync;
+
+import com.google.inject.Inject;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.*;
+import net.runelite.api.annotations.Component;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.ScriptPostFired;
+import net.runelite.api.widgets.*;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.api.events.ScriptPreFired;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.client.eventbus.Subscribe;
+
+@Slf4j
+public class SyncButtonManager {
+
+    private static final int COLLECTION_LOG_SETUP = 7797;
+    private static final int[] SPRITE_IDS_INACTIVE = {
+            SpriteID.DIALOG_BACKGROUND,
+            SpriteID.WORLD_MAP_BUTTON_METAL_CORNER_TOP_LEFT,
+            SpriteID.WORLD_MAP_BUTTON_METAL_CORNER_TOP_RIGHT,
+            SpriteID.WORLD_MAP_BUTTON_METAL_CORNER_BOTTOM_LEFT,
+            SpriteID.WORLD_MAP_BUTTON_METAL_CORNER_BOTTOM_RIGHT,
+            SpriteID.WORLD_MAP_BUTTON_EDGE_LEFT,
+            SpriteID.WORLD_MAP_BUTTON_EDGE_TOP,
+            SpriteID.WORLD_MAP_BUTTON_EDGE_RIGHT,
+            SpriteID.WORLD_MAP_BUTTON_EDGE_BOTTOM,
+    };
+
+    private static final int[] SPRITE_IDS_ACTIVE = {
+            SpriteID.RESIZEABLE_MODE_SIDE_PANEL_BACKGROUND,
+            SpriteID.EQUIPMENT_BUTTON_METAL_CORNER_TOP_LEFT_HOVERED,
+            SpriteID.EQUIPMENT_BUTTON_METAL_CORNER_TOP_RIGHT_HOVERED,
+            SpriteID.EQUIPMENT_BUTTON_METAL_CORNER_BOTTOM_LEFT_HOVERED,
+            SpriteID.EQUIPMENT_BUTTON_METAL_CORNER_BOTTOM_RIGHT_HOVERED,
+            SpriteID.EQUIPMENT_BUTTON_EDGE_LEFT_HOVERED,
+            SpriteID.EQUIPMENT_BUTTON_EDGE_TOP_HOVERED,
+            SpriteID.EQUIPMENT_BUTTON_EDGE_RIGHT_HOVERED,
+            SpriteID.EQUIPMENT_BUTTON_EDGE_BOTTOM_HOVERED,
+    };
+
+    private static final int FONT_COLOUR_INACTIVE = 0xd6d6d6;
+    private static final int FONT_COLOUR_ACTIVE = 0xffffff;
+
+    private final Client client;
+    private final ClientThread clientThread;
+    private final EventBus eventBus;
+
+    @Inject
+    private SyncButtonManager(
+            Client client,
+            ClientThread clientThread,
+            EventBus eventBus
+    )
+    {
+        this.client = client;
+        this.clientThread = clientThread;
+        this.eventBus = eventBus;
+    }
+
+    public void startUp()
+    {
+        eventBus.register(this);
+        clientThread.invokeLater(() -> tryAddButton(this::onButtonClick));
+    }
+
+    public void shutDown()
+    {
+        eventBus.unregister(this);
+        clientThread.invokeLater(this::removeButton);
+    }
+
+//    @Subscribe
+//    public void onMenuOptionClicked(MenuOptionClicked m) {
+//        log.error("opt {}", m.getMenuOption());
+//        log.error("action {}", m.getMenuAction().toString());
+//        log.error("p0 {}", m.getParam0());
+//        log.error("p1 {}", m.getParam1());
+//        log.error("id {}", m.getId());
+//        log.error("itemId {}", m.getItemId());
+//        log.error("target {}", m.getMenuTarget());
+//    }
+
+    @Getter
+    @RequiredArgsConstructor
+    enum Screen
+    {
+        // First number is col log container (inner) and second is search button id
+        COLLECTION_LOG(40697944, 40697932, ComponentID.COLLECTION_LOG_CONTAINER, 55),
+        ;
+
+        /**
+         * parent widget of the interface, install target
+         */
+        @Getter(onMethod_ = @Component)
+        private final int parentId;
+
+        /**
+         * the "Set Bonus" button widget layer
+         */
+        @Getter(onMethod_ = @Component)
+        private final int searchButtonId;
+
+        @Getter(onMethod_ = @Component)
+        private final int collectionLogContainer;
+
+        /**
+         * OriginalX for Set Bonus and Stat Bonus, prior to us moving them around (for shutdown)
+         **/
+        private final int originalX;
+
+    }
+
+    void tryAddButton(Runnable onClick)
+    {
+        for (Screen screen : Screen.values())
+        {
+            addButton(screen, onClick);
+        }
+    }
+    @Subscribe
+    public void onScriptPostFired(ScriptPostFired scriptPostFired)
+    {
+        if (scriptPostFired.getScriptId() == COLLECTION_LOG_SETUP)
+        {
+            removeButton();
+            addButton(Screen.COLLECTION_LOG, this::onButtonClick);
+        }
+    }
+
+    void onButtonClick() {
+        client.menuAction(-1, 40697932, MenuAction.CC_OP, 1, -1, "Search", null);
+        client.addChatMessage(ChatMessageType.CONSOLE, "WikiSync", "Your collection log data is being sent to WikiSync...", "WikiSync");
+    }
+
+    /**
+     * Shifts over the Set Bonus / Stat Bonus buttons
+     * and adds new widgets to make a visually equal button with a different name.
+     */
+    void addButton(Screen screen, Runnable onClick)
+    {
+        Widget parent = client.getWidget(screen.getParentId());
+        Widget setBonus = client.getWidget(screen.getSearchButtonId());
+        Widget collectionLogContainer = client.getWidget(screen.getCollectionLogContainer());
+        Widget[] containerChildren;
+        Widget draggableTopbar;
+        Widget[] refComponents;
+        if (parent == null || setBonus == null || collectionLogContainer == null ||
+            (containerChildren = collectionLogContainer.getChildren()) == null ||
+                (draggableTopbar = containerChildren[0]) == null  ||
+                (refComponents = setBonus.getChildren()) == null)
+        {
+            return;
+        }
+
+        // Since the Set Bonus button uses absolute positioning,
+        // we must also use absolute for all the children below,
+        // which means it's necessary to offset the values by simulating corresponding pos/size modes.
+        final int w = setBonus.getOriginalWidth();
+        final int h = setBonus.getOriginalHeight();
+        final int x = parent.getOriginalWidth() - 103;
+        final int y = setBonus.getOriginalY();
+
+        final Widget[] spriteWidgets = new Widget[9];
+
+        // the background uses ABSOLUTE_CENTER and MINUS sizing
+        int bgWidth = w - refComponents[0].getOriginalWidth();
+        int bgHeight = h - refComponents[0].getOriginalHeight();
+        int bgX = (x) + (w - bgWidth) / 2;
+        int bgY = (y) + (h - bgHeight) / 2;
+        spriteWidgets[0] = parent.createChild(-1, WidgetType.GRAPHIC)
+                .setSpriteId(refComponents[0].getSpriteId())
+                .setPos(bgX, bgY)
+                .setSize(bgWidth, bgHeight)
+                .setYPositionMode(setBonus.getYPositionMode());
+        spriteWidgets[0].revalidate();
+
+        // borders and corners
+        for (int i = 1; i < 9; i++)
+        {
+            Widget c = spriteWidgets[i] = parent.createChild(-1, WidgetType.GRAPHIC)
+                    .setSpriteId(refComponents[i].getSpriteId())
+                    .setSize(refComponents[i].getOriginalWidth(), refComponents[i].getOriginalHeight())
+                    .setPos(x + refComponents[i].getOriginalX(), y + refComponents[i].getOriginalY());
+            spriteWidgets[i].revalidate();
+        }
+
+        final Widget text = parent.createChild(-1, WidgetType.TEXT)
+                .setText("WikiSync")
+                .setTextColor(FONT_COLOUR_INACTIVE)
+                .setFontId(refComponents[10].getFontId())
+                .setTextShadowed(refComponents[10].getTextShadowed())
+                .setXTextAlignment(WidgetTextAlignment.CENTER)
+                .setYTextAlignment(WidgetTextAlignment.CENTER)
+                .setPos(x, y)
+                .setSize(w, h)
+                .setYPositionMode(setBonus.getYPositionMode());
+        text.revalidate();
+
+        // We'll give the text layer the listeners since it covers the whole area
+        text.setHasListener(true);
+        text.setOnMouseOverListener((JavaScriptCallback) ev ->
+        {
+            for (int i = 0; i <= 8; i++)
+            {
+                spriteWidgets[i].setSpriteId(SPRITE_IDS_ACTIVE[i]);
+            }
+            text.setTextColor(FONT_COLOUR_ACTIVE);
+        });
+        text.setOnMouseLeaveListener((JavaScriptCallback) ev ->
+        {
+            for (int i = 0; i <= 8; i++)
+            {
+                spriteWidgets[i].setSpriteId(SPRITE_IDS_INACTIVE[i]);
+            }
+            text.setTextColor(FONT_COLOUR_INACTIVE);
+        });
+
+        // register a click listener
+        text.setAction(0, "Sync your collection log with WikiSync");
+        text.setOnOpListener((JavaScriptCallback) ev -> onClick.run());
+
+
+        //Shrink the top bar to avoid overlapping the new button
+        draggableTopbar.setOriginalWidth(draggableTopbar.getWidth() - w);
+        draggableTopbar.revalidate();
+
+        // recompute locations / sizes on parent
+        parent.revalidate();
+    }
+
+    void removeButton()
+    {
+        for (Screen screen : Screen.values())
+        {
+            Widget parent = client.getWidget(screen.getParentId());
+            if (parent != null)
+            {
+                parent.deleteAllChildren();
+                parent.revalidate();
+            }
+        }
+    }
+}

--- a/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
+++ b/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
@@ -74,17 +74,6 @@ public class SyncButtonManager {
         clientThread.invokeLater(this::removeButton);
     }
 
-//    @Subscribe
-//    public void onMenuOptionClicked(MenuOptionClicked m) {
-//        log.error("opt {}", m.getMenuOption());
-//        log.error("action {}", m.getMenuAction().toString());
-//        log.error("p0 {}", m.getParam0());
-//        log.error("p1 {}", m.getParam1());
-//        log.error("id {}", m.getId());
-//        log.error("itemId {}", m.getItemId());
-//        log.error("target {}", m.getMenuTarget());
-//    }
-
     @Getter
     @RequiredArgsConstructor
     enum Screen
@@ -93,26 +82,16 @@ public class SyncButtonManager {
         COLLECTION_LOG(40697944, 40697932, ComponentID.COLLECTION_LOG_CONTAINER, 55),
         ;
 
-        /**
-         * parent widget of the interface, install target
-         */
         @Getter(onMethod_ = @Component)
         private final int parentId;
 
-        /**
-         * the "Set Bonus" button widget layer
-         */
         @Getter(onMethod_ = @Component)
         private final int searchButtonId;
 
         @Getter(onMethod_ = @Component)
         private final int collectionLogContainer;
 
-        /**
-         * OriginalX for Set Bonus and Stat Bonus, prior to us moving them around (for shutdown)
-         **/
         private final int originalX;
-
     }
 
     void tryAddButton(Runnable onClick)
@@ -137,10 +116,6 @@ public class SyncButtonManager {
         client.addChatMessage(ChatMessageType.CONSOLE, "WikiSync", "Your collection log data is being sent to WikiSync...", "WikiSync");
     }
 
-    /**
-     * Shifts over the Set Bonus / Stat Bonus buttons
-     * and adds new widgets to make a visually equal button with a different name.
-     */
     void addButton(Screen screen, Runnable onClick)
     {
         Widget parent = client.getWidget(screen.getParentId());
@@ -157,9 +132,6 @@ public class SyncButtonManager {
             return;
         }
 
-        // Since the Set Bonus button uses absolute positioning,
-        // we must also use absolute for all the children below,
-        // which means it's necessary to offset the values by simulating corresponding pos/size modes.
         final int w = setBonus.getOriginalWidth();
         final int h = setBonus.getOriginalHeight();
         final int x = parent.getOriginalWidth() - 103;
@@ -167,7 +139,6 @@ public class SyncButtonManager {
 
         final Widget[] spriteWidgets = new Widget[9];
 
-        // the background uses ABSOLUTE_CENTER and MINUS sizing
         int bgWidth = w - refComponents[0].getOriginalWidth();
         int bgHeight = h - refComponents[0].getOriginalHeight();
         int bgX = (x) + (w - bgWidth) / 2;

--- a/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
+++ b/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
@@ -113,6 +113,7 @@ public class SyncButtonManager {
 
     void onButtonClick() {
         client.menuAction(-1, 40697932, MenuAction.CC_OP, 1, -1, "Search", null);
+        client.menuAction(-1, 40697932, MenuAction.CC_OP, 1, -1, "Back", null);
         client.addChatMessage(ChatMessageType.CONSOLE, "WikiSync", "Your collection log data is being sent to WikiSync...", "WikiSync");
     }
 
@@ -150,7 +151,6 @@ public class SyncButtonManager {
                 .setYPositionMode(setBonus.getYPositionMode());
         spriteWidgets[0].revalidate();
 
-        // borders and corners
         for (int i = 1; i < 9; i++)
         {
             Widget c = spriteWidgets[i] = parent.createChild(-1, WidgetType.GRAPHIC)

--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -99,10 +99,8 @@ public class WikiSyncPlugin extends Plugin
 	private static final int SECONDS_BETWEEN_UPLOADS = 10;
 	private static final int SECONDS_BETWEEN_MANIFEST_CHECKS = 1200;
 
-//	private static final String MANIFEST_URL = "https://sync.runescape.wiki/runelite/manifest";
-//	private static final String SUBMIT_URL = "https://sync.runescape.wiki/runelite/submit";
-	private static final String MANIFEST_URL = "http://localhost:3000/runelite/manifest";
-	private static final String SUBMIT_URL = "http://localhost:3000/runelite/submit";
+	private static final String MANIFEST_URL = "https://sync.runescape.wiki/runelite/manifest";
+	private static final String SUBMIT_URL = "https://sync.runescape.wiki/runelite/submit";
 	private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
 	private static final int VARBITS_ARCHIVE_ID = 14;

--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -201,7 +201,6 @@ public class WikiSyncPlugin extends Plugin
 	private int lookupItemIndex(int itemId) {
         // The map has not loaded yet, or failed to load.
 		if (collectionsMap.isEmpty()) {
-            log.error("Manifest has no collections data");
 			return -1;
 		}
 		Integer result = collectionsMap.get(itemId);
@@ -229,6 +228,12 @@ public class WikiSyncPlugin extends Plugin
 	@Subscribe
 	public void onScriptPreFired(ScriptPreFired preFired) {
 		if (preFired.getScriptId() == 4100) {
+			if (collectionsMap.isEmpty())
+			{
+				log.error("Manifest has no collections data");
+				return;
+			}
+
 			Object[] args = preFired.getScriptEvent().getArguments();
 			int itemId = (int) args[1];
 			int idx = lookupItemIndex(itemId);

--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -92,10 +92,8 @@ public class WikiSyncPlugin extends Plugin
 	private static final int SECONDS_BETWEEN_UPLOADS = 10;
 	private static final int SECONDS_BETWEEN_MANIFEST_CHECKS = 1200;
 
-//	private static final String MANIFEST_URL = "https://sync.runescape.wiki/runelite/manifest";
-//	private static final String SUBMIT_URL = "https://sync.runescape.wiki/runelite/submit";
-	private static final String MANIFEST_URL = "http://localhost:3000/runelite/manifest";
-	private static final String SUBMIT_URL = "http://localhost:3000/runelite/submit";
+	private static final String MANIFEST_URL = "https://sync.runescape.wiki/runelite/manifest";
+	private static final String SUBMIT_URL = "https://sync.runescape.wiki/runelite/submit";
 	private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
 	private static final int VARBITS_ARCHIVE_ID = 14;
@@ -123,6 +121,7 @@ public class WikiSyncPlugin extends Plugin
 	@Override
 	public void startUp()
 	{
+		clogItemsBitSet.clear();
 		clientThread.invoke(() -> {
 			if (client.getIndexConfig() == null || client.getGameState().ordinal() < GameState.LOGIN_SCREEN.ordinal())
 			{
@@ -181,6 +180,7 @@ public class WikiSyncPlugin extends Plugin
 	protected void shutDown()
 	{
 		log.debug("WikiSync stopped!");
+		clogItemsBitSet.clear();
 		shutDownWebSocketManager();
 		syncButtonManager.shutDown();
 	}
@@ -377,7 +377,6 @@ public class WikiSyncPlugin extends Plugin
 				.post(RequestBody.create(JSON, gson.toJson(submission)))
 				.build();
 
-		log.error(delta.collectionLog);
 		Call call = okHttpClient.newCall(request);
 		call.timeout().timeout(3, TimeUnit.SECONDS);
 		call.enqueue(new Callback()

--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -86,11 +86,16 @@ public class WikiSyncPlugin extends Plugin
 	@Inject
 	private OkHttpClient okHttpClient;
 
+	@Inject
+	private SyncButtonManager syncButtonManager;
+
 	private static final int SECONDS_BETWEEN_UPLOADS = 10;
 	private static final int SECONDS_BETWEEN_MANIFEST_CHECKS = 1200;
 
-	private static final String MANIFEST_URL = "https://sync.runescape.wiki/runelite/manifest";
-	private static final String SUBMIT_URL = "https://sync.runescape.wiki/runelite/submit";
+//	private static final String MANIFEST_URL = "https://sync.runescape.wiki/runelite/manifest";
+//	private static final String SUBMIT_URL = "https://sync.runescape.wiki/runelite/submit";
+	private static final String MANIFEST_URL = "http://localhost:3000/runelite/manifest";
+	private static final String SUBMIT_URL = "http://localhost:3000/runelite/submit";
 	private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
 	private static final int VARBITS_ARCHIVE_ID = 14;
@@ -136,6 +141,7 @@ public class WikiSyncPlugin extends Plugin
 		if (config.enableLocalWebSocketServer()) {
 			startUpWebSocketManager();
 		}
+		syncButtonManager.startUp();
 	}
 
     private HashSet<Integer> parseCacheForClog()
@@ -176,6 +182,7 @@ public class WikiSyncPlugin extends Plugin
 	{
 		log.debug("WikiSync stopped!");
 		shutDownWebSocketManager();
+		syncButtonManager.shutDown();
 	}
 
 	private void shutDownWebSocketManager()
@@ -365,6 +372,7 @@ public class WikiSyncPlugin extends Plugin
 				.post(RequestBody.create(JSON, gson.toJson(submission)))
 				.build();
 
+		log.error(delta.collectionLog);
 		Call call = okHttpClient.newCall(request);
 		call.timeout().timeout(3, TimeUnit.SECONDS);
 		call.enqueue(new Callback()

--- a/stub_server.py
+++ b/stub_server.py
@@ -11,6 +11,7 @@ class TestResource:
         resp.media = {
             'varbits': [0, 100, 9657, 4101, 5000, 10000, 4104],
             'varps': [1, 3, 5, 6, 7, 10],
+            'collections': [],
             'version': 4
         }
         resp.status = falcon.HTTP_200


### PR DESCRIPTION
Receives an ordering of items from the manifest and uses that to construct a bitmap that is then encoded via b64. This is saved server side. You need to click the button in the collection log interface to submit and resubmit. There is no partial submit support based on messages for now.

We need `parseCacheForClog` because there may be items that the server does not know about that we still want to pack. This function parses the cache and lets us know what should be in the collection log, then when we pull down the manifest we look for missing items. Missing items are appended in itemId order at the end of the list.
When we update the manifest on the server, we can update it in the same way to minimize issues.

Right now, this resets the bitmap whenever you hop or log out. This is a little aggressive but falling out of sync is bad here. Note that for now the server is union-ing the existing and the new bitmap it is passed, so passing up an empty string is not going to clear existing data. I eventually want to clean this up to avoid doing a union on the server, but also making it more explicit that we are not passing up any collection log data from the server's POV. I don't want to block on that though