### PR TITLE
Move clog init after gamestate check to avoid client.getEnum null ptr-ing

### DIFF
--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -120,7 +120,7 @@ public class WikiSyncPlugin extends Plugin
 	// Map item ids to bit index in the bitset
 	private static final HashMap<Integer, Integer> collectionLogItemIdToBitsetIndex = new HashMap<>();
 	private int tickCollectionLogScriptFired = -1;
-	private HashSet<Integer> collectionLogItemIdsFromCache;
+	private final HashSet<Integer> collectionLogItemIdsFromCache = new HashSet<>();
 
 	@Provides
 	WikiSyncConfig getConfig(ConfigManager configManager)
@@ -133,12 +133,12 @@ public class WikiSyncPlugin extends Plugin
 	{
 		clogItemsBitSet.clear();
 		clientThread.invoke(() -> {
-			collectionLogItemIdsFromCache = parseCacheForClog();
 			if (client.getIndexConfig() == null || client.getGameState().ordinal() < GameState.LOGIN_SCREEN.ordinal())
 			{
 				log.debug("Failed to get varbitComposition, state = {}", client.getGameState());
 				return false;
 			}
+			collectionLogItemIdsFromCache.addAll(parseCacheForClog());
 			final int[] varbitIds = client.getIndexConfig().getFileIds(VARBITS_ARCHIVE_ID);
 			for (int id : varbitIds)
 			{

--- a/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
+++ b/src/main/java/com/andmcadams/wikisync/WikiSyncPlugin.java
@@ -131,7 +131,6 @@ public class WikiSyncPlugin extends Plugin
 	@Override
 	public void startUp()
 	{
-		clogItemsBitSet.clear();
 		clientThread.invoke(() -> {
 			if (client.getIndexConfig() == null || client.getGameState().ordinal() < GameState.LOGIN_SCREEN.ordinal())
 			{
@@ -168,6 +167,7 @@ public class WikiSyncPlugin extends Plugin
 	{
 		log.debug("WikiSync stopped!");
 		clogItemsBitSet.clear();
+		clogItemsCount = null;
 		shutDownWebSocketManager();
 		syncButtonManager.shutDown();
 	}
@@ -208,6 +208,7 @@ public class WikiSyncPlugin extends Plugin
 			case LOGGING_IN:
 			case CONNECTION_LOST:
 				clogItemsBitSet.clear();
+				clogItemsCount = null;
 				break;
 		}
 	}


### PR DESCRIPTION
We were getting reports of some random submission failures with no obvious issues. In some of the logs we could see the attached stack traces, which seemed to point to client.getEnum erroring out. I think this has to do with the cache parse being attempted before the gamestate check, which might put us in a state where we try to get the enum before the cache is ready.

I moved the cache parsing to wait until we are at least at the LOGIN_SCREEN state and made it so failing to parse the cache will not stop us from sending data. In addition, I made it so that we will attempt to set up the item id -> bitset bit index after we finish parsing the cache (in case the manifest finished first) and after we finish retrieving the manifest (in case the cache finished first).

```
2025-02-09 10:43:25 KST [Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
wg: 
	at td.ah(td.java:20884)
	at hd.ah(hd.java:30)
	at client.rl(client.java:16785)
	at client.getEnum(client.java:6272)
	at com.andmcadams.wikisync.WikiSyncPlugin.parseCacheForClog(WikiSyncPlugin.java:497)
	at com.andmcadams.wikisync.WikiSyncPlugin.lambda$startUp$0(WikiSyncPlugin.java:136)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:226)
	at client.fr(client.java:2261)
	at client.bd(client.java)
	at bt.ap(bt.java:393)
	at bt.av(bt.java)
	at bt.run(bt.java:19683)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NullPointerException: null
	at hd.ah(hd.java:31)
	... 13 common frames omitted
2025-02-09 10:43:26 KST [Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
java.lang.NullPointerException: null
	at com.andmcadams.wikisync.WikiSyncPlugin$2.lambda$onResponse$1(WikiSyncPlugin.java:446)
	at net.runelite.client.callback.ClientThread.lambda$invoke$0(ClientThread.java:49)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:226)
	at client.fr(client.java:2261)
	at client.bd(client.java)
	at bt.ap(bt.java:393)
	at bt.av(bt.java)
	at bt.run(bt.java:19683)
	at java.base/java.lang.Thread.run(Unknown Source)
```