### PR TITLE
Migrate to using gamevals 

### DIFF
--- a/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
+++ b/src/main/java/com/andmcadams/wikisync/SyncButtonManager.java
@@ -8,10 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.annotations.Component;
 import net.runelite.api.events.ScriptPostFired;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.EventBus;
-import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.eventbus.Subscribe;
 
 @Slf4j
@@ -86,7 +86,7 @@ public class SyncButtonManager {
     enum Screen
     {
         // First number is col log container (inner) and second is search button id
-        COLLECTION_LOG(40697944, 40697932, ComponentID.COLLECTION_LOG_CONTAINER),
+        COLLECTION_LOG(InterfaceID.Collection.UNIVERSE, InterfaceID.Collection.SEARCH_TOGGLE, InterfaceID.Collection.INFINITY),
         ;
 
         @Getter(onMethod_ = @Component)
@@ -118,7 +118,7 @@ public class SyncButtonManager {
 
     void onButtonClick() {
         setSyncAllowed(true);
-        client.menuAction(-1, 40697932, MenuAction.CC_OP, 1, -1, "Search", null);
+        client.menuAction(-1, InterfaceID.Collection.SEARCH_TOGGLE, MenuAction.CC_OP, 1, -1, "Search", null);
         client.runScript(2240);
         client.addChatMessage(ChatMessageType.CONSOLE, "WikiSync", "Your collection log data is being sent to WikiSync...", "WikiSync");
     }

--- a/src/main/java/com/andmcadams/wikisync/dps/DpsDataFetcher.java
+++ b/src/main/java/com/andmcadams/wikisync/dps/DpsDataFetcher.java
@@ -13,16 +13,16 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.GameState;
-import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
-import net.runelite.api.ItemID;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
-import net.runelite.api.VarPlayer;
-import net.runelite.api.Varbits;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 
@@ -83,7 +83,7 @@ public class DpsDataFetcher
 		if (slot == EquipmentInventorySlot.BOOTS && itemContainer.count() == 1 && itemContainer.contains(ItemID.CHEFS_HAT))
 		{
 			JsonObject o = new JsonObject();
-			o.addProperty("id", ItemID.SNAIL_SHELL);
+			o.addProperty("id", ItemID.TEMPLETREK_SNAIL_SHELL);
 			return o;
 		}
 
@@ -105,7 +105,7 @@ public class DpsDataFetcher
 
 		// Build the player's loadout data
 		JsonArray loadouts = new JsonArray();
-		ItemContainer eqContainer = client.getItemContainer(InventoryID.EQUIPMENT);
+		ItemContainer eqContainer = client.getItemContainer(InventoryID.WORN);
 
 		JsonObject l = new JsonObject();
 		JsonObject eq = new JsonObject();
@@ -135,10 +135,10 @@ public class DpsDataFetcher
 		l.add("skills", skills);
 
 		JsonObject buffs = new JsonObject();
-		buffs.addProperty("inWilderness", client.getVarbitValue(Varbits.IN_WILDERNESS) == 1);
-		buffs.addProperty("kandarinDiary", client.getVarbitValue(Varbits.DIARY_KANDARIN_HARD) == 1);
-		buffs.addProperty("onSlayerTask", client.getVarpValue(VarPlayer.SLAYER_TASK_SIZE) > 0);
-		buffs.addProperty("chargeSpell", client.getVarpValue(VarPlayer.CHARGE_GOD_SPELL) > 0);
+		buffs.addProperty("inWilderness", client.getVarbitValue(VarbitID.INSIDE_WILDERNESS) == 1);
+		buffs.addProperty("kandarinDiary", client.getVarbitValue(VarbitID.KANDARIN_DIARY_HARD_COMPLETE) == 1);
+		buffs.addProperty("onSlayerTask", client.getVarpValue(VarPlayerID.SLAYER_COUNT) > 0);
+		buffs.addProperty("chargeSpell", client.getVarpValue(VarPlayerID.MAGEARENA_CHARGE) > 0);
 		l.add("buffs", buffs);
 
 		l.addProperty("name", client.getLocalPlayer().getName());


### PR DESCRIPTION
Updates the plugin to use gameval-based constants from the RuneLite API where possible.

Mostly automated via abex's migration script, but the constants to match the bare ints in [L89](https://github.com/cdfisher/WikiSync/commit/cf8ecd6fb4886010a4740a69704ca38b6a110d4b#diff-be5b4a5aa42b341152cfa6c1335548549103eca388be300d873ead01591990b2R12-R89) and [L121](https://github.com/cdfisher/WikiSync/commit/cf8ecd6fb4886010a4740a69704ca38b6a110d4b#diff-be5b4a5aa42b341152cfa6c1335548549103eca388be300d873ead01591990b2R121) were found via the devtools widget inspector.
